### PR TITLE
asaas/api: removing puts endpoint configuration to avoid annoying log

### DIFF
--- a/lib/asaas/api/base.rb
+++ b/lib/asaas/api/base.rb
@@ -14,7 +14,6 @@ module Asaas
         @route    = route
         @api_version = api_version || Asaas::Configuration.api_version
         @endpoint = Asaas::Configuration.get_endpoint(api_version)
-        puts @endpoint
       end
 
       def extract_meta(meta)
@@ -94,7 +93,7 @@ module Asaas
             method: method,
             body: body,
             params: params,
-            headers: { 
+            headers: {
               'access_token': @token || Asaas::Configuration.token,
               'Content-Type': 'application/json'
              },


### PR DESCRIPTION
Esse PR remove um `puts` deixado dentro da classe `api/base` . Toda vez que os testes rodam ou é feita uma chamada esse puts aparece nos logs. 