### PR TITLE
chore: adiciona campo de deleted para o customer

### DIFF
--- a/lib/asaas/models/customer.rb
+++ b/lib/asaas/models/customer.rb
@@ -19,5 +19,6 @@ module Asaas
     attribute :municipalInscription, Types::Coercible::String.optional.default(nil)
     attribute :stateInscription, Types::Coercible::String.optional.default(nil)
     attribute :groupName, Types::Coercible::String.optional.default(nil)
+    attribute :deleted, Types::Coercible::Bool.optional.default(false)
   end
 end


### PR DESCRIPTION
Um jeito de saber se o customer que estamos buscando no asaas foi deletedado na base deles ou não é por meio do campo deleted que é retornado pelo asaas.