### PR TITLE
fix: corrige tipo do campo deleted do customer

### DIFF
--- a/lib/asaas/models/customer.rb
+++ b/lib/asaas/models/customer.rb
@@ -19,6 +19,6 @@ module Asaas
     attribute :municipalInscription, Types::Coercible::String.optional.default(nil)
     attribute :stateInscription, Types::Coercible::String.optional.default(nil)
     attribute :groupName, Types::Coercible::String.optional.default(nil)
-    attribute :deleted, Types::Coercible::Bool.optional.default(false)
+    attribute :deleted, Types::Bool.optional.default(false)
   end
 end


### PR DESCRIPTION
# Problema

Na atualização anterior subiu um erro de tipo para o campo deleted no model de customer, o erro se trata do tipo Bool qu foi pasado com o Coecible.

# Solução

Remove o Coercible para tornar o Bool no tipo correto.